### PR TITLE
Basic PDF Table of Contents

### DIFF
--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -473,6 +473,39 @@ module CombinePDF
       end
     end
 
+    # Overwrites any existing outline given a title, page_number mapping
+    def create_page_outline(outline_entries, document_title = "Document")
+      return if outline_entries.empty?
+      doc_outline = {
+        Title: document_title
+      }
+      root_outline = {
+        Type: :Outlines,
+        First: { referenced_object: doc_outline, is_reference_only: true },
+        Last: { referenced_object: doc_outline, is_reference_only: true },
+        Count: 1
+      }
+      page_entries = []
+      outline_entries.each do |p|
+        page_entries << {
+          Title: p[:title],
+          Parent: { referenced_object: doc_outline, is_reference_only: true },
+          Dest: { referenced_object: self.pages[p[:page_number]], is_reference_only: true },
+        }
+      end
+      page_entries.each_with_index do |p, idx|
+        unless idx==0
+          p[:Prev] = { referenced_object: page_entries[idx-1], is_reference_only: true }
+        end
+        unless idx == page_entries.length-1
+          p[:Next] = { referenced_object: page_entries[idx+1], is_reference_only: true }
+        end
+      end
+      doc_outline[:First] = { referenced_object: page_entries.first, is_reference_only: true }
+      doc_outline[:Last] = { referenced_object: page_entries.last, is_reference_only: true }
+      @outlines = root_outline
+    end
+
     # the form_data attribute is a Hash that corresponds to the PDF form data (if any).
     attr_reader :forms_data
 

--- a/lib/combine_pdf/pdf_public.rb
+++ b/lib/combine_pdf/pdf_public.rb
@@ -485,7 +485,16 @@ module CombinePDF
         Last: { referenced_object: doc_outline, is_reference_only: true },
         Count: 1
       }
+
+      page_entries = build_page_entries(outline_entries, doc_outline)
+      add_page_links(page_entries, doc_outline)
+
+      @outlines = root_outline
+    end
+
+    def build_page_entries(outline_entries, doc_outline)
       page_entries = []
+
       outline_entries.each do |p|
         page_entries << {
           Title: p[:title],
@@ -493,6 +502,11 @@ module CombinePDF
           Dest: { referenced_object: self.pages[p[:page_number]], is_reference_only: true },
         }
       end
+
+      page_entries
+    end
+
+    def add_page_links(page_entries, doc_outline)
       page_entries.each_with_index do |p, idx|
         unless idx==0
           p[:Prev] = { referenced_object: page_entries[idx-1], is_reference_only: true }
@@ -503,7 +517,6 @@ module CombinePDF
       end
       doc_outline[:First] = { referenced_object: page_entries.first, is_reference_only: true }
       doc_outline[:Last] = { referenced_object: page_entries.last, is_reference_only: true }
-      @outlines = root_outline
     end
 
     # the form_data attribute is a Hash that corresponds to the PDF form data (if any).

--- a/lib/combine_pdf/renderer.rb
+++ b/lib/combine_pdf/renderer.rb
@@ -125,7 +125,11 @@ module CombinePDF
       # (using LESS-THAN SIGNs (3Ch) and GREATER-THAN SIGNs (3Eh)).
       out << "<<\n".force_encoding(Encoding::ASCII_8BIT)
       object.each do |key, value|
-        out << "#{object_to_pdf key} #{object_to_pdf value}\n".force_encoding(Encoding::ASCII_8BIT) unless PDF::PRIVATE_HASH_KEYS.include? key
+        if key == :Dest
+          out << "#{object_to_pdf key} [#{object_to_pdf value} /Fit]\n".force_encoding(Encoding::ASCII_8BIT) unless PDF::PRIVATE_HASH_KEYS.include? key
+        else
+          out << "#{object_to_pdf key} #{object_to_pdf value}\n".force_encoding(Encoding::ASCII_8BIT) unless PDF::PRIVATE_HASH_KEYS.include? key
+        end
       end
       object.delete :Length
       out << '>>'.force_encoding(Encoding::ASCII_8BIT)


### PR DESCRIPTION
* Fix :Dest key to write correctly
* Allow an array of [titles, page_numbers] to be passed into generate a basic PDF table of contents (overwrites any existing data)